### PR TITLE
Update train-conda.yml Python to 3.8

### DIFF
--- a/data-science/environment/train-conda.yml
+++ b/data-science/environment/train-conda.yml
@@ -3,7 +3,7 @@ channels:
   - anaconda
   - conda-forge
 dependencies:
-  - python=3.7.5
+  - python=3.8
   - pip
   - pip:
       - azureml-mlflow==1.38.0


### PR DESCRIPTION
azureml-inference-server-http requires Python >=3.8 
address issue #7 